### PR TITLE
feat(counter): Add builders check-in count implementation

### DIFF
--- a/packages/nextjs/app/_components/BuildersCheckInCount.tsx
+++ b/packages/nextjs/app/_components/BuildersCheckInCount.tsx
@@ -1,24 +1,41 @@
-"use client";
-
-import React from "react";
 import { CounterDisplay } from "./CounterDisplay";
-import { useScaffoldReadContract } from "~~/hooks/scaffold-eth";
+import { createPublicClient, getContract, http } from "viem";
+import { optimism } from "viem/chains";
 
-const CONTRACT_NAME = "BatchRegistry";
+const CONTRACT_ADR = "0x72ccAbE6620fa94eC69569d17f18a3914BEFBFD6";
 const FUNCTION_NAME = "checkedInCounter";
 
-function BuildersCheckInCount() {
-  // Get the result of the target function call from the deployed contract
-  const {
-    data: counter,
-    isLoading,
-    error,
-  } = useScaffoldReadContract({
-    contractName: CONTRACT_NAME,
-    functionName: FUNCTION_NAME,
-  });
+// Defining the ABI for just the function we need
+const BatchRegistryABI = [
+  {
+    name: FUNCTION_NAME,
+    type: "function",
+    stateMutability: "view",
+    inputs: [],
+    outputs: [{ type: "uint256" }],
+  },
+] as const;
 
-  return <CounterDisplay data={counter} isLoading={isLoading} error={error} />;
+async function BuildersCheckInCount() {
+  try {
+    // A Client in the context of viem is similar to an Ethers.js Provider.
+    const publicClient = createPublicClient({
+      chain: optimism,
+      transport: http(),
+    });
+
+    const contract = getContract({
+      address: CONTRACT_ADR,
+      abi: BatchRegistryABI,
+      client: publicClient,
+    });
+
+    const counter = await contract.read.checkedInCounter();
+
+    return <CounterDisplay data={counter} error={null} />;
+  } catch (error) {
+    return <CounterDisplay data={undefined} error={error instanceof Error ? error : new Error("Unknown error")} />;
+  }
 }
 
 export default BuildersCheckInCount;

--- a/packages/nextjs/app/_components/BuildersCheckInCount.tsx
+++ b/packages/nextjs/app/_components/BuildersCheckInCount.tsx
@@ -2,58 +2,32 @@
 
 import React from "react";
 import { displayTxResult } from "../debug/_components/contract";
-import { useReadContract } from "wagmi";
 import { ArrowPathIcon } from "@heroicons/react/24/outline";
-import { useDeployedContractInfo, useTargetNetwork } from "~~/hooks/scaffold-eth";
+import { useScaffoldReadContract } from "~~/hooks/scaffold-eth";
 
 const CONTRACT_NAME = "BatchRegistry";
-
-// Define the ABI for the BatchRegistry contract
-// The ABI is a JSON object that defines the functions and their parameters of a contract
-// Could be generated from the contract's ABI file or manually created
-// Check packages/nextjs/app/debug/_components/contract/ContractVariables.tsx for an example of how to use the ABI programmatically
-const BatchRegistryABI = {
-  checkedInCounter: {
-    name: "checkedInCounter",
-    type: "function",
-    stateMutability: "view",
-    inputs: [],
-    outputs: [{ type: "uint256" }],
-  },
-} as const;
+const FUNCTION_NAME = "checkedInCounter";
 
 function BuildersCheckInCount() {
-  // Get the deployed contract data
-  const { data: deployedContractData, isLoading: deployedContractLoading } = useDeployedContractInfo({
-    contractName: CONTRACT_NAME,
-  });
-
-  const { targetNetwork } = useTargetNetwork();
-
   // Get the result of the target function call from the deployed contract
   const {
-    data: result,
-    isFetching,
+    data: counter,
+    isLoading,
     error,
-  } = useReadContract({
-    address: deployedContractData?.address,
-    functionName: BatchRegistryABI.checkedInCounter.name,
-    abi: [BatchRegistryABI.checkedInCounter],
-    chainId: targetNetwork.id,
-    query: {
-      retry: false,
-    },
+  } = useScaffoldReadContract({
+    contractName: CONTRACT_NAME,
+    functionName: FUNCTION_NAME,
   });
 
   return (
     <div className="text-lg flex gap-2 justify-center items-center">
       <span className="font-bold">Checked in builders count:</span>
-      {deployedContractLoading || isFetching ? (
+      {isLoading || (!error && !counter) ? (
         <ArrowPathIcon className="size-5 animate-spin" />
       ) : error ? (
         <span className="text-error">Error!</span>
       ) : (
-        <span>{displayTxResult(result)}</span>
+        <span>{displayTxResult(counter)}</span>
       )}
     </div>
   );

--- a/packages/nextjs/app/_components/BuildersCheckInCount.tsx
+++ b/packages/nextjs/app/_components/BuildersCheckInCount.tsx
@@ -1,8 +1,7 @@
 "use client";
 
 import React from "react";
-import { displayTxResult } from "../debug/_components/contract";
-import { ArrowPathIcon } from "@heroicons/react/24/outline";
+import { CounterDisplay } from "./CounterDisplay";
 import { useScaffoldReadContract } from "~~/hooks/scaffold-eth";
 
 const CONTRACT_NAME = "BatchRegistry";
@@ -19,18 +18,7 @@ function BuildersCheckInCount() {
     functionName: FUNCTION_NAME,
   });
 
-  return (
-    <div className="text-lg flex gap-2 justify-center items-center">
-      <span className="font-bold">Checked in builders count:</span>
-      {isLoading || (!error && !counter) ? (
-        <ArrowPathIcon className="size-5 animate-spin" />
-      ) : error ? (
-        <span className="text-error">Error!</span>
-      ) : (
-        <span>{displayTxResult(counter)}</span>
-      )}
-    </div>
-  );
+  return <CounterDisplay data={counter} isLoading={isLoading} error={error} />;
 }
 
 export default BuildersCheckInCount;

--- a/packages/nextjs/app/_components/BuildersCheckInCount.tsx
+++ b/packages/nextjs/app/_components/BuildersCheckInCount.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import React from "react";
+import { displayTxResult } from "../debug/_components/contract";
+import { useReadContract } from "wagmi";
+import { ArrowPathIcon } from "@heroicons/react/24/outline";
+import { useDeployedContractInfo, useTargetNetwork } from "~~/hooks/scaffold-eth";
+
+const CONTRACT_NAME = "BatchRegistry";
+
+// Define the ABI for the BatchRegistry contract
+// The ABI is a JSON object that defines the functions and their parameters of a contract
+// Could be generated from the contract's ABI file or manually created
+// Check packages/nextjs/app/debug/_components/contract/ContractVariables.tsx for an example of how to use the ABI programmatically
+const BatchRegistryABI = {
+  checkedInCounter: {
+    name: "checkedInCounter",
+    type: "function",
+    stateMutability: "view",
+    inputs: [],
+    outputs: [{ type: "uint256" }],
+  },
+} as const;
+
+function BuildersCheckInCount() {
+  // Get the deployed contract data
+  const { data: deployedContractData, isLoading: deployedContractLoading } = useDeployedContractInfo({
+    contractName: CONTRACT_NAME,
+  });
+
+  const { targetNetwork } = useTargetNetwork();
+
+  // Get the result of the target function call from the deployed contract
+  const {
+    data: result,
+    isFetching,
+    error,
+  } = useReadContract({
+    address: deployedContractData?.address,
+    functionName: BatchRegistryABI.checkedInCounter.name,
+    abi: [BatchRegistryABI.checkedInCounter],
+    chainId: targetNetwork.id,
+    query: {
+      retry: false,
+    },
+  });
+
+  return (
+    <div className="text-lg flex gap-2 justify-center items-center">
+      <span className="font-bold">Checked in builders count:</span>
+      {deployedContractLoading || isFetching ? (
+        <ArrowPathIcon className="size-5 animate-spin" />
+      ) : error ? (
+        <span className="text-error">Error!</span>
+      ) : (
+        <span>{displayTxResult(result)}</span>
+      )}
+    </div>
+  );
+}
+
+export default BuildersCheckInCount;

--- a/packages/nextjs/app/_components/CounterDisplay.tsx
+++ b/packages/nextjs/app/_components/CounterDisplay.tsx
@@ -1,0 +1,25 @@
+import { displayTxResult } from "../debug/_components/contract";
+import { ArrowPathIcon } from "@heroicons/react/16/solid";
+
+export async function CounterDisplay({
+  data: counter,
+  isLoading,
+  error,
+}: {
+  data?: bigint;
+  isLoading: boolean;
+  error: Error | null;
+}) {
+  return (
+    <div className="text-lg flex gap-2 justify-center items-center">
+      <span className="font-bold">Checked in builders count:</span>
+      {isLoading || (!error && !counter) ? (
+        <ArrowPathIcon className="size-5 animate-spin" />
+      ) : error ? (
+        <span className="text-error">Error!</span>
+      ) : (
+        <span>{displayTxResult(counter)}</span>
+      )}
+    </div>
+  );
+}

--- a/packages/nextjs/app/_components/CounterDisplay.tsx
+++ b/packages/nextjs/app/_components/CounterDisplay.tsx
@@ -1,25 +1,11 @@
-import { displayTxResult } from "../debug/_components/contract";
-import { ArrowPathIcon } from "@heroicons/react/16/solid";
-
-export async function CounterDisplay({
-  data: counter,
-  isLoading,
-  error,
-}: {
-  data?: bigint;
-  isLoading: boolean;
-  error: Error | null;
-}) {
+export async function CounterDisplay({ data: counter, error }: { data?: bigint; error: Error | null }) {
   return (
     <div className="text-lg flex gap-2 justify-center items-center">
       <span className="font-bold">Checked in builders count:</span>
-      {isLoading || (!error && !counter) ? (
-        <ArrowPathIcon className="size-5 animate-spin" />
-      ) : error ? (
-        <span className="text-error">Error!</span>
-      ) : (
-        <span>{displayTxResult(counter)}</span>
-      )}
+
+      {error && <span className="text-error">Error!</span>}
+
+      {counter && <span>{counter.toString()}</span>}
     </div>
   );
 }

--- a/packages/nextjs/app/page.tsx
+++ b/packages/nextjs/app/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import Link from "next/link";
+import BuildersCheckInCount from "./_components/BuildersCheckInCount";
 import type { NextPage } from "next";
 import { BugAntIcon, MagnifyingGlassIcon } from "@heroicons/react/24/outline";
 
@@ -14,10 +15,7 @@ const Home: NextPage = () => {
             <span className="block text-4xl font-bold">Batch 12</span>
           </h1>
           <p className="text-center text-lg">Get started by taking a look at your batch GitHub repository.</p>
-          <p className="text-lg flex gap-2 justify-center">
-            <span className="font-bold">Checked in builders count:</span>
-            <span>To Be Implemented</span>
-          </p>
+          <BuildersCheckInCount />
         </div>
 
         <div className="flex-grow bg-base-300 w-full mt-16 px-8 py-12">

--- a/packages/nextjs/app/page.tsx
+++ b/packages/nextjs/app/page.tsx
@@ -1,8 +1,7 @@
-import { Suspense } from "react";
 import Link from "next/link";
 import BuildersCheckInCount from "./_components/BuildersCheckInCount";
 import type { NextPage } from "next";
-import { ArrowPathIcon, BugAntIcon, MagnifyingGlassIcon } from "@heroicons/react/24/outline";
+import { BugAntIcon, MagnifyingGlassIcon } from "@heroicons/react/24/outline";
 
 const Home: NextPage = () => {
   return (
@@ -14,9 +13,7 @@ const Home: NextPage = () => {
             <span className="block text-4xl font-bold">Batch 12</span>
           </h1>
           <p className="text-center text-lg">Get started by taking a look at your batch GitHub repository.</p>
-          <Suspense fallback={<LoadingCounter />}>
-            <BuildersCheckInCount />
-          </Suspense>
+          <BuildersCheckInCount />
         </div>
 
         <div className="flex-grow bg-base-300 w-full mt-16 px-8 py-12">
@@ -49,11 +46,3 @@ const Home: NextPage = () => {
 };
 
 export default Home;
-function LoadingCounter() {
-  return (
-    <div className="text-lg flex gap-2 justify-center items-center">
-      <span className="font-bold">Checked in builders count:</span>
-      <ArrowPathIcon className="size-5 animate-spin" />
-    </div>
-  );
-}

--- a/packages/nextjs/app/page.tsx
+++ b/packages/nextjs/app/page.tsx
@@ -1,9 +1,8 @@
-"use client";
-
+import { Suspense } from "react";
 import Link from "next/link";
 import BuildersCheckInCount from "./_components/BuildersCheckInCount";
 import type { NextPage } from "next";
-import { BugAntIcon, MagnifyingGlassIcon } from "@heroicons/react/24/outline";
+import { ArrowPathIcon, BugAntIcon, MagnifyingGlassIcon } from "@heroicons/react/24/outline";
 
 const Home: NextPage = () => {
   return (
@@ -15,7 +14,9 @@ const Home: NextPage = () => {
             <span className="block text-4xl font-bold">Batch 12</span>
           </h1>
           <p className="text-center text-lg">Get started by taking a look at your batch GitHub repository.</p>
-          <BuildersCheckInCount />
+          <Suspense fallback={<LoadingCounter />}>
+            <BuildersCheckInCount />
+          </Suspense>
         </div>
 
         <div className="flex-grow bg-base-300 w-full mt-16 px-8 py-12">
@@ -48,3 +49,11 @@ const Home: NextPage = () => {
 };
 
 export default Home;
+function LoadingCounter() {
+  return (
+    <div className="text-lg flex gap-2 justify-center items-center">
+      <span className="font-bold">Checked in builders count:</span>
+      <ArrowPathIcon className="size-5 animate-spin" />
+    </div>
+  );
+}


### PR DESCRIPTION
## Description
Implemented builders check-in counter with two possible ABI handling approaches:

Current Implementation:
```typescript
// Direct ABI definition approach
const BatchRegistryABI = {
  checkedInCounter: {
    name: "checkedInCounter",
    type: "function",
    stateMutability: "view",
    inputs: [],
    outputs: [{ type: "uint256" }],
  },
} as const;
```

Alternative Approach (from ContractVariables.tsx):
```typescript
// Dynamic ABI filtering approach
const abiFunction = (deployedContractData?.abi as Abi)?.filter(
  part => part.type === "function" && part.name === TARGET_FUNCTION_NAME,
)[0] as AbiFunction;
```

Implementation Considerations:
- Direct ABI is more performant (no runtime filtering for only one function) and more readable
- Dynamic approach is more flexible for contract updates
- Both maintain type safety

Which approach would be preferred in this context?

## Additional Information
- [x] Following issue requirements
- [x] Added inline documentation explaining both approaches
- [x] Added comparative analysis in comments

## Related Issues
Closes #8

Your ENS/address: 0x7d971C39bb700AcEc20879D46f092dC0DB1dbF9E
