### PR TITLE
Add profile page for Ludmila (Definn)

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,5 +53,8 @@
   },
   "engines": {
     "node": ">=18.18.0"
+  },
+  "dependencies": {
+    "react-icons": "^5.4.0"
   }
 }

--- a/packages/nextjs/app/builders/0xC3b8BBD76c78a0dFAf47b4454472DB35cEBD1A24/page.tsx
+++ b/packages/nextjs/app/builders/0xC3b8BBD76c78a0dFAf47b4454472DB35cEBD1A24/page.tsx
@@ -1,0 +1,112 @@
+"use client";
+
+import Image from "next/image";
+import type { NextPage } from "next";
+import { FaGithub, FaTwitter } from "react-icons/fa";
+import { SiFarcaster } from "react-icons/si";
+import { TbPlant2 } from "react-icons/tb";
+import { Address } from "~~/components/scaffold-eth";
+
+const LudmilaProfile: NextPage = () => {
+  const address = "0xC3b8BBD76c78a0dFAf47b4454472DB35cEBD1A24";
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-pink-100 via-blue-100 to-purple-100 dark:from-gray-800 dark:via-purple-900 dark:to-blue-900 flex flex-col items-center">
+      <div className="w-full max-w-4xl bg-white dark:bg-gray-800 shadow-lg rounded-lg p-6 mt-10">
+        <div className="flex items-center space-x-6">
+          <div className="avatar">
+            <Image
+              src="https://avatars.githubusercontent.com/u/16783967"
+              alt="@ludmila-omlopes"
+              width={100}
+              height={100}
+              className="rounded-full ring ring-primary"
+            />
+          </div>
+          <div>
+            <h1 className="text-2xl font-bold">@ludmila-omlopes</h1>
+            <Address address={address} />
+            <p className="text-sm text-gray-600 dark:text-gray-400">🌟 Professional Generalist</p>
+          </div>
+        </div>
+        <div className="flex mt-4 gap-4">
+          <a
+            href="https://github.com/ludmila-omlopes"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-gray-800 dark:text-white hover:text-blue-500 dark:hover:text-blue-300 transition"
+            aria-label="GitHub"
+          >
+            <FaGithub size={24} />
+          </a>
+          <a
+            href="https://hey.xyz/u/definn"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-gray-800 dark:text-white hover:text-green-500 dark:hover:text-green-300 transition"
+            aria-label="Lens"
+          >
+            <TbPlant2 size={24} />
+          </a>
+          <a
+            href="https://twitter.com/DeFinnTheFarmer"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-gray-800 dark:text-white hover:text-blue-400 dark:hover:text-blue-300 transition"
+            aria-label="Twitter"
+          >
+            <FaTwitter size={24} />
+          </a>
+          <a
+            href="https://warpcast.com/definn.eth"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-gray-800 dark:text-white hover:text-purple-500 dark:hover:text-purple-300 transition"
+            aria-label="Farcaster"
+          >
+            <SiFarcaster size={24} />
+          </a>
+        </div>
+      </div>
+
+      {/* About Section */}
+      <div className="w-full max-w-4xl bg-white dark:bg-gray-800 shadow-lg rounded-lg p-6 mt-6">
+        <h2 className="text-lg font-semibold mb-2">About Me</h2>
+        <p>
+          I&apos;m Ludmila, a Brazilian woman and primarily a <strong>developer</strong> but also with experience in
+          <strong> SEO, marketing, and growth</strong>. Currently passionate about solving problems in the{" "}
+          <a
+            href="https://lens.xyz"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-blue-500 hover:underline"
+          >
+            Lens Protocol
+          </a>{" "}
+          ecosystem, I&apos;ve been building in the crypto space since 2017.
+        </p>
+        <p>
+          I&apos;m building{" "}
+          <a href="https://lens.xyz" className="text-blue-500 hover:underline">
+            Mystic Garden
+          </a>
+          ,{" "}
+          <a href="https://oriona.xyz/" className="text-blue-500 hover:underline">
+            Oriona
+          </a>
+          , and{" "}
+          <a href="https://lens-agora.vercel.app/" className="text-blue-500 hover:underline">
+            Lens Agora
+          </a>
+          . These projects aim to empower communities and creators in the web3 space.
+        </p>
+        <p>
+          In my free time, I enjoy gaming and spending time with my three cats 😺😺😺. Feel free to connect if
+          you&apos;d like to learn more about my projects!
+        </p>
+      </div>
+    </div>
+  );
+};
+
+export default LudmilaProfile;

--- a/packages/nextjs/app/builders/0xC3b8BBD76c78a0dFAf47b4454472DB35cEBD1A24/page.tsx
+++ b/packages/nextjs/app/builders/0xC3b8BBD76c78a0dFAf47b4454472DB35cEBD1A24/page.tsx
@@ -36,7 +36,7 @@ const socialMediaLinks = [
     hoverColor: "hover:text-blue-500 dark:hover:text-blue-300",
   },
   {
-    href: "https://lens.xyz/u/definn",
+    href: "https://hey.xyz/u/definn",
     ariaLabel: "Lens",
     icon: <TbPlant2 size={24} />,
     hoverColor: "hover:text-green-500 dark:hover:text-green-300",

--- a/packages/nextjs/app/builders/0xC3b8BBD76c78a0dFAf47b4454472DB35cEBD1A24/page.tsx
+++ b/packages/nextjs/app/builders/0xC3b8BBD76c78a0dFAf47b4454472DB35cEBD1A24/page.tsx
@@ -7,70 +7,93 @@ import { SiFarcaster } from "react-icons/si";
 import { TbPlant2 } from "react-icons/tb";
 import { Address } from "~~/components/scaffold-eth";
 
+interface SocialMediaIconProps {
+  href: string;
+  ariaLabel: string;
+  icon: React.ReactNode;
+  hoverColor: string;
+}
+
+function SocialMediaIcon({ href, ariaLabel, icon, hoverColor }: SocialMediaIconProps) {
+  return (
+    <a
+      href={href}
+      target="_blank"
+      rel="noopener noreferrer"
+      aria-label={ariaLabel}
+      className={`text-gray-800 dark:text-white transition ${hoverColor}`}
+    >
+      {icon}
+    </a>
+  );
+}
+
+const socialMediaLinks = [
+  {
+    href: "https://github.com/ludmila-omlopes",
+    ariaLabel: "GitHub",
+    icon: <FaGithub size={24} />,
+    hoverColor: "hover:text-blue-500 dark:hover:text-blue-300",
+  },
+  {
+    href: "https://lens.xyz/u/definn",
+    ariaLabel: "Lens",
+    icon: <TbPlant2 size={24} />,
+    hoverColor: "hover:text-green-500 dark:hover:text-green-300",
+  },
+  {
+    href: "https://twitter.com/DeFinnTheFarmer",
+    ariaLabel: "Twitter",
+    icon: <FaTwitter size={24} />,
+    hoverColor: "hover:text-blue-400 dark:hover:text-blue-300",
+  },
+  {
+    href: "https://warpcast.com/definn.eth",
+    ariaLabel: "Farcaster",
+    icon: <SiFarcaster size={24} />,
+    hoverColor: "hover:text-purple-500 dark:hover:text-purple-300",
+  },
+];
+
 const LudmilaProfile: NextPage = () => {
   const address = "0xC3b8BBD76c78a0dFAf47b4454472DB35cEBD1A24";
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-pink-100 via-blue-100 to-purple-100 dark:from-gray-800 dark:via-purple-900 dark:to-blue-900 flex flex-col items-center">
-      <div className="w-full max-w-4xl bg-white dark:bg-gray-800 shadow-lg rounded-lg p-6 mt-10">
-        <div className="flex items-center space-x-6">
-          <div className="avatar">
-            <Image
-              src="https://avatars.githubusercontent.com/u/16783967"
-              alt="@ludmila-omlopes"
-              width={100}
-              height={100}
-              className="rounded-full ring ring-primary"
-            />
+      <div className="w-full max-w-4xl bg-white dark:bg-gray-800 shadow-lg rounded-lg p-6 mt-10 relative">
+        <div className="flex items-start">
+          <div className="flex-1 flex items-center space-x-6">
+            <div className="avatar">
+              <Image
+                src="https://avatars.githubusercontent.com/u/16783967"
+                alt="@ludmila-omlopes"
+                width={100}
+                height={100}
+                className="rounded-full ring ring-primary"
+              />
+            </div>
+            <div>
+              <h1 className="text-3xl font-bold">Ludmila Lopes (DeFinn)</h1>
+              <Address address={address} />
+              <p className="text-sm text-gray-600 dark:text-gray-400 mt-2">🌟 Professional Generalist</p>
+            </div>
           </div>
-          <div>
-            <h1 className="text-2xl font-bold">@ludmila-omlopes</h1>
-            <Address address={address} />
-            <p className="text-sm text-gray-600 dark:text-gray-400">🌟 Professional Generalist</p>
+          {/* Social Media Icons */}
+          <div className="top-0 right-0 flex flex-col items-center gap-2">
+            {socialMediaLinks.map((link, index) => (
+              <SocialMediaIcon
+                key={index}
+                href={link.href}
+                ariaLabel={link.ariaLabel}
+                icon={link.icon}
+                hoverColor={link.hoverColor}
+              />
+            ))}
           </div>
-        </div>
-        <div className="flex mt-4 gap-4">
-          <a
-            href="https://github.com/ludmila-omlopes"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="text-gray-800 dark:text-white hover:text-blue-500 dark:hover:text-blue-300 transition"
-            aria-label="GitHub"
-          >
-            <FaGithub size={24} />
-          </a>
-          <a
-            href="https://hey.xyz/u/definn"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="text-gray-800 dark:text-white hover:text-green-500 dark:hover:text-green-300 transition"
-            aria-label="Lens"
-          >
-            <TbPlant2 size={24} />
-          </a>
-          <a
-            href="https://twitter.com/DeFinnTheFarmer"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="text-gray-800 dark:text-white hover:text-blue-400 dark:hover:text-blue-300 transition"
-            aria-label="Twitter"
-          >
-            <FaTwitter size={24} />
-          </a>
-          <a
-            href="https://warpcast.com/definn.eth"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="text-gray-800 dark:text-white hover:text-purple-500 dark:hover:text-purple-300 transition"
-            aria-label="Farcaster"
-          >
-            <SiFarcaster size={24} />
-          </a>
         </div>
       </div>
 
-      {/* About Section */}
-      <div className="w-full max-w-4xl bg-white dark:bg-gray-800 shadow-lg rounded-lg p-6 mt-6">
+      <div className="w-full max-w-4xl bg-white dark:bg-gray-800 shadow-lg rounded-lg p-6 mt-6 text-left">
         <h2 className="text-lg font-semibold mb-2">About Me</h2>
         <p>
           I&apos;m Ludmila, a Brazilian woman and primarily a <strong>developer</strong> but also with experience in

--- a/yarn.lock
+++ b/yarn.lock
@@ -11444,6 +11444,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"react-icons@npm:^5.4.0":
+  version: 5.4.0
+  resolution: "react-icons@npm:5.4.0"
+  peerDependencies:
+    react: "*"
+  checksum: 6ee5fcda49d9628e33d97e955ed6ec9f30b26226a13b14d0f3f9a698d0d5dd2e3878af7de295e0241bdd8f46af96f16bfea1fd0647beddc447c1de98bdb2178e
+  languageName: node
+  linkType: hard
+
 "react-is@npm:^16.13.1":
   version: 16.13.1
   resolution: "react-is@npm:16.13.1"
@@ -11993,6 +12002,7 @@ __metadata:
   dependencies:
     husky: ^9.1.6
     lint-staged: ^15.2.10
+    react-icons: ^5.4.0
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## Description

This PR adds a personalized profile page for me, Ludmila (aka Definn) (@ludmila-omlopes) to the project. The page includes:
- A responsive layout with a pastel gradient background supporting light and dark themes.
- Social links for GitHub, Lens, Twitter, and Farcaster as icons.
- Details about Ludmila's projects (*Mystic Garden*, *Oriona*, and *Lens Agora*), her developer background, and her personal interests.

Screenshots of the profile page:
![image](https://github.com/user-attachments/assets/43a10d81-64df-49fa-8cb0-3307d9b56407)
![image](https://github.com/user-attachments/assets/c2b8f44d-8602-4473-b088-237a246c3a9f)


## Additional Information

- [x] I have read the [contributing docs](/scaffold-eth/scaffold-eth-2/blob/main/CONTRIBUTING.md) (This is my first contribution)
- [x] This is not a duplicate of any [existing pull request](https://github.com/scaffold-eth/scaffold-eth-2/pulls)

## Related Issues
#11 

My ENS/address:  
`0xC3b8BBD76c78a0dFAf47b4454472DB35cEBD1A24`
